### PR TITLE
[TECH] Changer le nom du workflow release 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  automerge:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: 1024pix/pix-actions/release@main


### PR DESCRIPTION
## :unicorn: Problème
Actuellement le workflow release s'appelle automerge

## :robot: Proposition
> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
