### PR TITLE
[FEATURE] Récupérer le numéro de PR 

### DIFF
--- a/src/parserOpts.js
+++ b/src/parserOpts.js
@@ -3,12 +3,11 @@ export function createParserOpts () {
     gitRawCommitsOpts: {
       merges: null
     },
-    headerPattern: /^\[(.*)] (.*)$/,
+    headerPattern: /^\[(.*)] (.*)$|#(\d+)/,
     headerCorrespondence: [
       'tag',
       'scope',
+      'pr'
     ],
-    mergePattern: /(#.*)/,
-    mergeCorrespondence: ['pr'],
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous ne récupérons pas le numéro de PR pour le mettre dans le changelog.

Cela est du au fait que seulement le titre de la PR passe dans mergePattern le body lui passe en headerPattern (cf: https://github.com/conventional-changelog/conventional-changelog/blob/eb3ab7bcd2266cd751e94c583510c8a85216a027/packages/conventional-commits-parser/README.md?plain=1#L170) 

## :robot: Proposition
Le catcher dans le header pattern

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
