### PR TITLE
[FEATURE] Récupérer le numéro de PR pour le mettre dans le changelog.

### DIFF
--- a/src/parserOpts.js
+++ b/src/parserOpts.js
@@ -9,5 +9,10 @@ export function createParserOpts () {
       'scope',
       'pr'
     ],
+    mergePattern: /^\[(.*)] (.*)$/,
+    mergeCorrespondence: [
+      'tag',
+      'scope'
+    ],
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous n'avons pas le numéro de PR correspondant au commit dans le changelog

En lisant [la documentation](https://github.com/conventional-changelog/conventional-changelog/blob/eb3ab7bcd2266cd751e94c583510c8a85216a027/packages/conventional-commits-parser/README.md?plain=1#L170), nous pouvons voir qu'il existe des merges pattern auquel cas ça sera le body sera pris en compte par le headerPattern.

## :robot: Proposition
> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
