### PR TITLE
[BUGFIX] Supprimer des options redondante du package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "type": "module",
   "version": "0.3.0",
   "description": "conventional-changelog pix preset",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
   "exports": {
     ".": {
       "require": "./dist/index.cjs",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, notre action release ne fonctionne plus. La piste envisagée est lié [à cette issue](https://github.com/sheerlox/import-from-esm/issues/92)

## :robot: Proposition
Supprimer le main et module du package.json afin de se baser que sur l'exports

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
