### PR TITLE
[TECH] Mettre à jour la version de node utilisé dans l'action `release`.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - run: npm ci
 


### PR DESCRIPTION
## :unicorn: Problème
On utilise une action version de l'action `actions/setup-node` et une la version 18 de Node.js.

## :robot: Proposition
Mettre à jour

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
