### PR TITLE
[FEATURE] Analyser uniquement les commits de merge

### DIFF
--- a/src/parserOpts.js
+++ b/src/parserOpts.js
@@ -1,7 +1,7 @@
 export function createParserOpts () {
   return {
     gitRawCommitsOpts: {
-      merges: null
+      merges: true
     },
     headerPattern: /^\[(.*)] (.*)$|#(\d+)/,
     headerCorrespondence: [


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous analysons tous les commits depuis la dernière release, hors c'est inutile avec notre workflow, où seulement les PR contiennent le tag qui permet de déclencher une release. 

## :robot: Proposition
Analyser uniquement les commits de merge

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
En local, dans le repo créer un fichier : `test.cjs` 
```javascript
const gitRawCommits = require('git-raw-commits');

const main = async () => {
  for await (let chunk of gitRawCommits({
    merges: true, from: 'v1.0.0', to: 'v2.0.0'
  }))
  {
    console.log(chunk.toString())
  }
}

main()

```

Regarder le resultat et voir qu'uniquement les commits de merges sont affichés