### PR TITLE
[BUGFIX] Générer le changelog uniquement avec les PRs

### DIFF
--- a/src/writerOpts.js
+++ b/src/writerOpts.js
@@ -22,6 +22,10 @@ export async function createWriterOpts () {
 function getWriterOpts () {
   return {
     transform: (commit) => {
+      if (!commit.pr) {
+        return
+      }
+
       if (commit.tag === 'BREAKING') {
         commit.tag = ':boom: BREAKING CHANGE'
       } else if (commit.tag === 'BUGFIX') {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,15 +13,17 @@ describe('conventional-changelog-ember', () => {
       testTools = new TestTools()
 
       testTools.gitInit()
-      testTools.gitDummyCommit(['[FEATURE] remove feature info and unflag tests', 'foo'])
-      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying .render to views/components.', 'bar'])
-      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying  # render to views/components.', 'bar'])
-      testTools.gitDummyCommit(['[TECH] Ensure primitive value contexts are escaped.'])
-      testTools.gitDummyCommit(['[DOC] Make ArrayProxy public'])
-      testTools.gitDummyCommit(['[BUMP] Mark Ember.Array methods as public'])
+      testTools.gitDummyCommit(['[FEATURE] remove feature info and unflag tests', ' #123'])
+      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying .render to views/components.', ' #456'])
+      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying  # render to views/components.', ' #789'])
+      testTools.gitDummyCommit(['[TECH] Ensure primitive value contexts are escaped.', ' #101112'])
+      testTools.gitDummyCommit(['[DOC] Make ArrayProxy public', ' #131415'])
+      testTools.gitDummyCommit(['[BUMP] Mark Ember.Array methods as public', ' #161718'])
       testTools.gitDummyCommit('Bad commit')
       testTools.gitDummyCommit('Merge pull request #2000000 from jayphelps/remove-ember-views-component-block-info')
       testTools.gitDummyCommit('Merge pull request #2 from jayphelps/remove-ember-views-component-block-info')
+      testTools.gitDummyCommit('Merge pull request #2 from jayphelps/remove-ember-views-component-block-info', ' #123')
+      testTools.gitDummyCommit('[FEATURE] No pr in description : should no appear in changelog')
     })
 
     afterEach(() => {
@@ -37,28 +39,28 @@ describe('conventional-changelog-ember', () => {
       )) {
         chunk = chunk.toString()
 
-        expect(chunk).toContain(`
-  ### :rocket: Amélioration
-  
-  - remove feature info and unflag tests
-  
-  ### :bug: Correction
-  
-  - Deprecate specifying  # render to views/components.
-  - Deprecate specifying .render to views/components.
-  
-  ### :building_construction: Tech
-  
-  - Ensure primitive value contexts are escaped.
-  
-  ### :arrow_up: Montée de version
-  
-  - Mark Ember.Array methods as public
-  
-  ### :coffee: Autre
-  
-  - Make ArrayProxy public
-  `)
+        const expectedOutput = `
+### :rocket: Amélioration
+
+- [#123](/pull/123) remove feature info and unflag tests
+
+### :bug: Correction
+
+- [#789](/pull/789) Deprecate specifying  # render to views/components.
+- [#456](/pull/456) Deprecate specifying .render to views/components.
+
+### :building_construction: Tech
+
+- [#101112](/pull/101112) Ensure primitive value contexts are escaped.
+
+### :arrow_up: Montée de version
+
+- [#161718](/pull/161718) Mark Ember.Array methods as public
+
+### :coffee: Autre
+
+- [#131415](/pull/131415) Make ArrayProxy public`
+        expect(chunk.includes(expectedOutput)).toBeTruthy()
 
         expect(chunk).not.toContain('CLEANUP')
         expect(chunk).not.toContain('FEATURE')


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, dans le changelog on peut aussi se retrouver avec des commits etc : 
![Screenshot 2024-03-06 at 14 51 02](https://github.com/1024pix/conventional-changelog-pix/assets/26384707/28d206c5-7dbf-4053-906b-096d1f146a2e)


## :robot: Proposition
Ajouter une condition pour ne prendre que les commits qui ont une pr associée. 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
