### PR TITLE
[FEATURE] Prendre en compte les PR de revert

### DIFF
--- a/src/parserOpts.js
+++ b/src/parserOpts.js
@@ -12,5 +12,11 @@ export function createParserOpts () {
       'tag',
       'scope'
     ],
+    revertPattern: /^(?:Revert)\s"\[?([\S]+?)]\s(.*)"[\s]+?#(\d+)/,
+    revertCorrespondence: [
+      'tag',
+      'scope',
+      'pr'
+    ],
   }
 }

--- a/src/writerOpts.js
+++ b/src/writerOpts.js
@@ -22,8 +22,14 @@ export async function createWriterOpts () {
 function getWriterOpts () {
   return {
     transform: (commit) => {
-      if (!commit.pr) {
+      if (!commit.pr && !commit.revert?.pr) {
         return
+      }
+
+      if (commit.revert) {
+        commit.pr = commit.revert.pr
+        commit.scope = commit.revert.scope
+        commit.tag = 'REVERT'
       }
 
       if (commit.tag === 'BREAKING') {
@@ -36,6 +42,8 @@ function getWriterOpts () {
         commit.tag = ':arrow_up: Montée de version'
       } else if (commit.tag === 'TECH') {
         commit.tag = ':building_construction: Tech'
+      } else if (commit.tag === 'REVERT') {
+        commit.tag = ':rewind: Retour en arrière'
       } else if (commit.tag) {
         commit.tag = ':coffee: Autre'
       }
@@ -52,6 +60,7 @@ function getWriterOpts () {
         ':boom: BREAKING CHANGE',
         ':rocket: Amélioration',
         ':bug: Correction',
+        ':rewind: Retour en arrière',
         ':building_construction: Tech',
         ':arrow_up: Montée de version',
         ':coffee: Autre'

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,12 +13,15 @@ describe('conventional-changelog-ember', () => {
       testTools = new TestTools()
 
       testTools.gitInit()
+      // good commits
       testTools.gitDummyCommit(['[FEATURE] remove feature info and unflag tests', ' #123'])
       testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying .render to views/components.', ' #456'])
       testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying  # render to views/components.', ' #789'])
       testTools.gitDummyCommit(['[TECH] Ensure primitive value contexts are escaped.', ' #101112'])
       testTools.gitDummyCommit(['[DOC] Make ArrayProxy public', ' #131415'])
       testTools.gitDummyCommit(['[BUMP] Mark Ember.Array methods as public', ' #161718'])
+      testTools.gitDummyCommit(['Revert \\"[TECH] Déplacer le plugin eslint 1024pix\\"', ' #101112'])
+      // Bad commmits
       testTools.gitDummyCommit('Bad commit')
       testTools.gitDummyCommit('Merge pull request #2000000 from jayphelps/remove-ember-views-component-block-info')
       testTools.gitDummyCommit('Merge pull request #2 from jayphelps/remove-ember-views-component-block-info')
@@ -48,6 +51,10 @@ describe('conventional-changelog-ember', () => {
 
 - [#789](/pull/789) Deprecate specifying  # render to views/components.
 - [#456](/pull/456) Deprecate specifying .render to views/components.
+
+### :rewind: Retour en arrière
+
+- [#101112](/pull/101112) Déplacer le plugin eslint 1024pix
 
 ### :building_construction: Tech
 

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -1,45 +1,80 @@
 import preset from '../src/index.js';
-import { describe, test, expect, vi } from 'vitest';
+import { beforeEach, describe, test, expect, vi } from 'vitest';
 import { sync as parser } from 'conventional-commits-parser';
 
 describe('Integration', () => {
   describe('conventional-commits-parser', () => {
-    test('it should return necessary fields', async () => {
-      const parserOpts = (await preset()).parserOpts;
-      const simpleCommit = parser("fix(scope1): First fix", parserOpts);
-      const mergeCommit = parser("[FEATURE] Second feature \n\n #12", parserOpts);
-      const commitWithTagButWithoutPRNumberInDescription = parser("[FEATURE] Third feature", parserOpts);
+    let parserOpts;
 
-      const pickNecessary = (commit) => {
-        return {
-          pr: commit.pr,
-          header: commit.header,
-          tag: commit.tag,
-          scope: commit.scope,
-          merge: commit.merge,
-        }
-      }
+    beforeEach(async () => {
+      parserOpts = (await preset()).parserOpts;
+    });
+
+    test('it should return null for conventional commits', async () => {
+      const simpleCommit = parser("fix(scope1): First fix", parserOpts);
+
       expect(pickNecessary(simpleCommit)).toEqual({
         header: "fix(scope1): First fix",
         pr: null,
         scope: null,
         tag: null,
         merge: null,
+        revert: null
       });
+    });
+
+    test('it should return necessary fields for Pix merge commit', async () => {
+      const mergeCommit = parser("[FEATURE] Second feature \n\n #12", parserOpts);
+
       expect(pickNecessary(mergeCommit)).toEqual({
         header: " #12",
         pr: "12",
         scope: "Second feature ",
         tag: "FEATURE",
-        merge: '[FEATURE] Second feature '
+        merge: '[FEATURE] Second feature ',
+        revert: null
       });
+    });
+
+    test('it should return necessary fields without pr when pr number is not in description', async () => {
+      const commitWithTagButWithoutPRNumberInDescription = parser("[FEATURE] Third feature", parserOpts);
+
       expect(pickNecessary(commitWithTagButWithoutPRNumberInDescription)).toEqual({
         header: '',
         merge: "[FEATURE] Third feature",
         pr: null,
         scope: "Third feature",
         tag: "FEATURE",
+        revert: null
+      });
+    });
+
+    test('revert commit should be parsed correctly', async () => {
+      const revertCommit = parser("Revert \"[TECH] Déplacer le plugin eslint 1024pix\"\n\n #123", parserOpts);
+
+      expect(pickNecessary(revertCommit)).toEqual({
+        header: "Revert \"[TECH] Déplacer le plugin eslint 1024pix\"",
+        scope: null,
+        tag: null,
+        merge: null,
+        pr: null,
+        revert: {
+          pr: "123",
+          scope: "Déplacer le plugin eslint 1024pix",
+          tag: "TECH",
+        }
       });
     });
   })
 });
+
+const pickNecessary = (commit) => {
+  return {
+    pr: commit.pr,
+    header: commit.header,
+    tag: commit.tag,
+    scope: commit.scope,
+    merge: commit.merge,
+    revert: commit.revert
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les PR de revert ne déclenche pas de release.

## :robot: Proposition
Ajouter un parsing spécifique pour détecter les revert, ainsi que le nécessaire pour l'écriture du changelog. 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
