### PR TITLE
[FEATURE] Prendre en compte les revert mergé manuellement.

### DIFF
--- a/src/parserOpts.js
+++ b/src/parserOpts.js
@@ -12,7 +12,7 @@ export function createParserOpts () {
       'tag',
       'scope'
     ],
-    revertPattern: /^(?:Revert)\s"\[?([\S]+?)]\s(.*)"[\s]+?#(\d+)/,
+    revertPattern: /^(?:Revert)\s"\[?([\S]+?)]\s(.*)"[\W]+?#(\d+)/,
     revertCorrespondence: [
       'tag',
       'scope',

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -65,6 +65,23 @@ describe('Integration', () => {
         }
       });
     });
+
+    test('revert commit should be parsed correctly with pr number in title', async () => {
+      const revertCommit = parser("Revert \"[TECH] Déplacer le plugin eslint 1024pix\" (#123)\n\n #123", parserOpts);
+
+      expect(pickNecessary(revertCommit)).toEqual({
+        header: "Revert \"[TECH] Déplacer le plugin eslint 1024pix\"",
+        scope: null,
+        tag: null,
+        merge: null,
+        pr: null,
+        revert: {
+          pr: "123",
+          scope: "Déplacer le plugin eslint 1024pix",
+          tag: "TECH",
+        }
+      });
+    });
   })
 });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsque nous faisons un revert et que nous mergeons pas soucis de rapidité une PR à la main ou de manque de coche la PR à la main, le titre peut être mal formatté et donc pas pris en compte par le parser. 

## :robot: Proposition
Rendre le parser plus souple pour accepter les merges manuel qui ont le numéro de PR dans le titre (généré par github quand on appuie sur le bouton merge) 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
