### PR TITLE
[FEATURE] Permettre le pattern de merge "Squash and merge" GitHub

### DIFF
--- a/src/parserOpts.js
+++ b/src/parserOpts.js
@@ -7,10 +7,11 @@ export function createParserOpts () {
     headerCorrespondence: [
       'pr'
     ],
-    mergePattern: /^\[(.*)] (.*)$/,
+    mergePattern: /^\[(.*)] (.*?)(?: \(#(\d+)\))?$/,
     mergeCorrespondence: [
       'tag',
-      'scope'
+      'scope',
+      'prNumberFromTitle'
     ],
     revertPattern: /^(?:Revert)\s"\[?([\S]+?)]\s(.*)"[\W]+?#(\d+)/,
     revertCorrespondence: [

--- a/src/writerOpts.js
+++ b/src/writerOpts.js
@@ -22,7 +22,7 @@ export async function createWriterOpts () {
 function getWriterOpts () {
   return {
     transform: (commit) => {
-      if (!commit.pr && !commit.revert?.pr) {
+      if (!commit.pr && !commit.revert?.pr && !commit.prNumberFromTitle) {
         return
       }
 
@@ -30,6 +30,10 @@ function getWriterOpts () {
         commit.pr = commit.revert.pr
         commit.scope = commit.revert.scope
         commit.tag = 'REVERT'
+      }
+
+      if (!commit.pr && commit.prNumberFromTitle) {
+        commit.pr = commit.prNumberFromTitle
       }
 
       if (commit.tag === 'BREAKING') {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -21,6 +21,7 @@ describe('conventional-changelog-ember', () => {
       testTools.gitDummyCommit(['[DOC] Make ArrayProxy public', ' #131415'])
       testTools.gitDummyCommit(['[BUMP] Mark Ember.Array methods as public', ' #161718'])
       testTools.gitDummyCommit(['Revert \\"[TECH] Déplacer le plugin eslint 1024pix\\"', ' #101112'])
+      testTools.gitDummyCommit(['[BREAKING] Break everything 😈 (#666)'])
       // Bad commmits
       testTools.gitDummyCommit('Bad commit')
       testTools.gitDummyCommit('Merge pull request #2000000 from jayphelps/remove-ember-views-component-block-info')
@@ -34,15 +35,11 @@ describe('conventional-changelog-ember', () => {
     })
 
     it('should return changelog with specific order', async () => {
-      for await (let chunk of conventionalChangelogCore(
-        {
-          cwd: testTools.cwd,
-          config: preset
-        }
-      )) {
-        chunk = chunk.toString()
+      const expectedOutput = `
+### :boom: BREAKING CHANGE
 
-        const expectedOutput = `
+- [#666](/pull/666) Break everything 😈
+
 ### :rocket: Amélioration
 
 - [#123](/pull/123) remove feature info and unflag tests
@@ -67,12 +64,16 @@ describe('conventional-changelog-ember', () => {
 ### :coffee: Autre
 
 - [#131415](/pull/131415) Make ArrayProxy public`
-        expect(chunk.includes(expectedOutput)).toBeTruthy()
 
-        expect(chunk).not.toContain('CLEANUP')
-        expect(chunk).not.toContain('FEATURE')
-        expect(chunk).not.toContain('Bad')
-      }
+      // when
+      let changelog = await getChangelog(testTools);
+
+      // then
+      expect(changelog).toContain(expectedOutput);
+
+      expect(changelog).not.toContain('CLEANUP')
+      expect(changelog).not.toContain('FEATURE')
+      expect(changelog).not.toContain('Bad')
     })
   })
 
@@ -120,3 +121,16 @@ describe('conventional-changelog-ember', () => {
     })
   })
 })
+
+async function getChangelog(testTools) {
+  let changelog = ``
+  for await (let chunk of conventionalChangelogCore(
+    {
+      cwd: testTools.cwd,
+      config: preset
+    }
+  )) {
+    changelog += chunk.toString();
+  }
+  return changelog;
+}

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -16,6 +16,7 @@ describe('Integration', () => {
       expect(pickNecessary(simpleCommit)).toEqual({
         header: "fix(scope1): First fix",
         pr: null,
+        prNumberFromTitle: null,
         scope: null,
         tag: null,
         merge: null,
@@ -23,7 +24,7 @@ describe('Integration', () => {
       });
     });
 
-    test('it should return necessary fields for Pix merge commit', async () => {
+    test('it should return necessary fields for Pix auto-merge commit', async () => {
       const mergeCommit = parser("[FEATURE] Second feature \n\n #12", parserOpts);
 
       expect(pickNecessary(mergeCommit)).toEqual({
@@ -32,7 +33,22 @@ describe('Integration', () => {
         scope: "Second feature ",
         tag: "FEATURE",
         merge: '[FEATURE] Second feature ',
-        revert: null
+        revert: null,
+        prNumberFromTitle: null,
+      });
+    });
+
+    test('it should return necessary fields for Pix  squash & merge commit', async () => {
+      const mergeCommit = parser("[FEATURE] Second feature (ISSUE-13202) (#12)", parserOpts);
+
+      expect(pickNecessary(mergeCommit)).toEqual({
+        header: "",
+        pr: null,
+        scope: "Second feature (ISSUE-13202)",
+        tag: "FEATURE",
+        merge: '[FEATURE] Second feature (ISSUE-13202) (#12)',
+        revert: null,
+        prNumberFromTitle: '12',
       });
     });
 
@@ -45,7 +61,8 @@ describe('Integration', () => {
         pr: null,
         scope: "Third feature",
         tag: "FEATURE",
-        revert: null
+        revert: null,
+        prNumberFromTitle: null,
       });
     });
 
@@ -58,6 +75,7 @@ describe('Integration', () => {
         tag: null,
         merge: null,
         pr: null,
+        prNumberFromTitle: null,
         revert: {
           pr: "123",
           scope: "Déplacer le plugin eslint 1024pix",
@@ -70,11 +88,12 @@ describe('Integration', () => {
       const revertCommit = parser("Revert \"[TECH] Déplacer le plugin eslint 1024pix\" (#123)\n\n #123", parserOpts);
 
       expect(pickNecessary(revertCommit)).toEqual({
-        header: "Revert \"[TECH] Déplacer le plugin eslint 1024pix\"",
+        header: "Revert \"[TECH] Déplacer le plugin eslint 1024pix\" (#123)",
         scope: null,
         tag: null,
         merge: null,
         pr: null,
+        prNumberFromTitle: null,
         revert: {
           pr: "123",
           scope: "Déplacer le plugin eslint 1024pix",
@@ -92,6 +111,7 @@ const pickNecessary = (commit) => {
     tag: commit.tag,
     scope: commit.scope,
     merge: commit.merge,
-    revert: commit.revert
+    revert: commit.revert,
+    prNumberFromTitle: commit.prNumberFromTitle,
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Les commits de merge fait avec le "squash and merge" GitHub ne sont pas parsés dans la génération de la release.

## :robot: Proposition
Les gérer.

## :rainbow: Remarques
Nous avons du utiliser un autre nom pour PR et faire le merge entre les deux noms car [le parser override les champs dans l'order : header puis merge](https://github.com/conventional-changelog/conventional-changelog/blob/299de5acbe55a7d19dcdd2adc34681eae7264abf/packages/conventional-commits-parser/lib/parser.js#L301)

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
