### PR TITLE
[BUGIFIX] Permet le bon parsing du premier tag

### DIFF
--- a/src/parserOpts.js
+++ b/src/parserOpts.js
@@ -7,7 +7,7 @@ export function createParserOpts () {
     headerCorrespondence: [
       'pr'
     ],
-    mergePattern: /^\[(.*)] (.*)$/,
+    mergePattern: /^\[([A-Z]+)\]?\s*(.*)$/,
     mergeCorrespondence: [
       'tag',
       'scope'

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -36,6 +36,19 @@ describe('Integration', () => {
       });
     });
 
+    test('it should return first targ for Pix merge commit even whith two tag', async () => {
+      const mergeCommit = parser("[BREAKING][DESIGN] Second feature \n\n #12", parserOpts);
+
+      expect(pickNecessary(mergeCommit)).toEqual({
+        header: " #12",
+        pr: "12",
+        scope: "[DESIGN] Second feature ",
+        tag: "BREAKING",
+        merge: '[BREAKING][DESIGN] Second feature ',
+        revert: null
+      });
+    });
+
     test('it should return necessary fields without pr when pr number is not in description', async () => {
       const commitWithTagButWithoutPRNumberInDescription = parser("[FEATURE] Third feature", parserOpts);
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on utilise deux tag [BREAKING][DESIGN], il en resultait tag : BREAKING][DESIGN .

## :robot: Proposition
Ne remontez que le Premier tag à savoir BREAKING

## :rainbow: Remarques
RAS

## :100: Pour tester
CI au vert