### PR TITLE
[BUGFIX] Rétirer l'espace nécessaire dans le commit de merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+      - run: npm ci
+      - run: npm test

--- a/src/parserOpts.js
+++ b/src/parserOpts.js
@@ -3,7 +3,7 @@ export function createParserOpts () {
     gitRawCommitsOpts: {
       merges: true
     },
-    headerPattern: / #(\d+)/,
+    headerPattern: /#(\d+)/,
     headerCorrespondence: [
       'pr'
     ],

--- a/src/writerOpts.js
+++ b/src/writerOpts.js
@@ -28,7 +28,7 @@ function getWriterOpts () {
 
       if (commit.revert) {
         commit.pr = commit.revert.pr
-        commit.scope = commit.revert.scope
+        commit.scope = `Revert "[${commit.revert.tag}] ${commit.revert.scope}"`
         commit.tag = 'REVERT'
       }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -14,9 +14,9 @@ describe('conventional-changelog-ember', () => {
 
       testTools.gitInit()
       // good commits
-      testTools.gitDummyCommit(['[FEATURE] remove feature info and unflag tests', ' #123'])
-      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying .render to views/components.', ' #456'])
-      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying  # render to views/components.', ' #789'])
+      testTools.gitDummyCommit(['[FEATURE] remove feature info and unflag tests', '#123'])
+      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying .render to views/components.', '#456'])
+      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying  # render to views/components.', '#789'])
       testTools.gitDummyCommit(['[TECH] Ensure primitive value contexts are escaped.', ' #101112'])
       testTools.gitDummyCommit(['[DOC] Make ArrayProxy public', ' #131415'])
       testTools.gitDummyCommit(['[BUMP] Mark Ember.Array methods as public', ' #161718'])
@@ -67,7 +67,7 @@ describe('conventional-changelog-ember', () => {
 ### :coffee: Autre
 
 - [#131415](/pull/131415) Make ArrayProxy public`
-        expect(chunk.includes(expectedOutput)).toBeTruthy()
+        await expect(chunk).to.contain(expectedOutput)
 
         expect(chunk).not.toContain('CLEANUP')
         expect(chunk).not.toContain('FEATURE')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -54,7 +54,7 @@ describe('conventional-changelog-ember', () => {
 
 ### :rewind: Retour en arrière
 
-- [#101112](/pull/101112) Déplacer le plugin eslint 1024pix
+- [#101112](/pull/101112) Revert "[TECH] Déplacer le plugin eslint 1024pix"
 
 ### :building_construction: Tech
 

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -67,17 +67,17 @@ describe('Integration', () => {
     });
 
     test('revert commit should be parsed correctly with pr number in title', async () => {
-      const revertCommit = parser("Revert \"[TECH] Déplacer le plugin eslint 1024pix\" (#123)\n\n #123", parserOpts);
+      const revertCommit = parser("Revert \"[TECH] Déplacer le plugin eslint 1024pix (PIX-1234)\"\n\n #123", parserOpts);
 
       expect(pickNecessary(revertCommit)).toEqual({
-        header: "Revert \"[TECH] Déplacer le plugin eslint 1024pix\"",
+        header: "Revert \"[TECH] Déplacer le plugin eslint 1024pix (PIX-1234)\"",
         scope: null,
         tag: null,
         merge: null,
         pr: null,
         revert: {
           pr: "123",
-          scope: "Déplacer le plugin eslint 1024pix",
+          scope: "Déplacer le plugin eslint 1024pix (PIX-1234)",
           tag: "TECH",
         }
       });


### PR DESCRIPTION
## 🌸 Problème
Actuellement, dans le commit de merge il est nécessaire d'avoir un espace, seulement lors d'un merge à la main nous pouvons oublier de le mettre.

## 🌳 Proposition

Faire en sorte de ne pas avoir besoin de cet espace
et ajouter une ci

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
