### PR TITLE
[FEATURE] Ne plus utiliser que les merge commits pour le changelog

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { whatBump } from './whatBump.js'
 export default async function createPreset () {
   return {
     commits: {
-      merges: true
+      merges: false
     },
     parser: createParserOpts(),
     writer: await createWriterOpts(),

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,22 +1,9 @@
 export function createParserOpts () {
   return {
-    gitRawCommitsOpts: {
-      merges: true
-    },
-    headerPattern: /#(\d+)/,
-    headerCorrespondence: [
-      'pr'
-    ],
-    mergePattern: /^\[(.*)] (.*)$/,
-    mergeCorrespondence: [
-      'tag',
-      'scope'
-    ],
-    revertPattern: /^(?:Revert)\s"\[?([\S]+?)]\s(.*)"[\W]+?#(\d+)/,
-    revertCorrespondence: [
-      'tag',
-      'scope',
-      'pr'
-    ],
+    gitRawCommitsOpts: { merges: false },
+    headerPattern: /^\[([^\]]+)\] (.+?)(?: \(#(\d+)\))?$/,
+    headerCorrespondence: ['tag', 'scope', 'pr'],
+    revertPattern: /^(?:Revert)\s"\[?([\S]+?)\]\s(.*)"[\W]+?#(\d+)/,
+    revertCorrespondence: ['tag', 'scope', 'pr'],
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -11,12 +11,7 @@ describe('conventional-changelog-pix', () => {
   let config;
 
   beforeEach(async () => {
-    config =  {
-      ...await preset(),
-      commits: {
-        merges: false // we do not do merge commits in tests
-      }
-    };
+    config =  await preset();
   })
 
   describe('Changelog', () => {
@@ -25,18 +20,18 @@ describe('conventional-changelog-pix', () => {
 
       testTools.gitInit()
       // good commits
-      testTools.gitDummyCommit(['[FEATURE] remove feature info and unflag tests', '#123'])
-      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying .render to views/components.', '#456'])
-      testTools.gitDummyCommit(['[BUGFIX] Deprecate specifying  # render to views/components.', '#789'])
-      testTools.gitDummyCommit(['[TECH] Ensure primitive value contexts are escaped.', ' #101112'])
-      testTools.gitDummyCommit(['[DOC] Make ArrayProxy public', ' #131415'])
-      testTools.gitDummyCommit(['[BUMP] Mark Ember.Array methods as public', ' #161718'])
-      testTools.gitDummyCommit(['Revert \\"[TECH] Déplacer le plugin eslint 1024pix\\"', ' #101112'])
+      testTools.gitDummyCommit('[FEATURE] remove feature info and unflag tests (PIX-1234) (#123)')
+      testTools.gitDummyCommit('[BUGFIX] Deprecate specifying .render to views/components. (#456)')
+      testTools.gitDummyCommit('[BUGFIX] Deprecate specifying  # render to views/components. (#789)')
+      testTools.gitDummyCommit('[TECH] Ensure primitive value contexts are escaped. (PIX-4567) (#101112)')
+      testTools.gitDummyCommit('[DOC] Make ArrayProxy public (#131415)')
+      testTools.gitDummyCommit('[BUMP] Mark Ember.Array methods as public (#161718)')
+      testTools.gitDummyCommit('Revert \\"[TECH] Déplacer le plugin eslint 1024pix (PIX-999) (#2)\\" (#101112)')
       // Bad commmits
       testTools.gitDummyCommit('Bad commit')
       testTools.gitDummyCommit('Merge pull request #2000000 from jayphelps/remove-ember-views-component-block-info')
       testTools.gitDummyCommit('Merge pull request #2 from jayphelps/remove-ember-views-component-block-info')
-      testTools.gitDummyCommit('Merge pull request #2 from jayphelps/remove-ember-views-component-block-info', ' #123')
+      testTools.gitDummyCommit('Merge pull request #2 from jayphelps/remove-ember-views-component-block-info (#123)')
       testTools.gitDummyCommit('[FEATURE] No pr in description : should no appear in changelog')
     })
 
@@ -48,14 +43,18 @@ describe('conventional-changelog-pix', () => {
       const conventionalChangelog = new ConventionalChangelog(testTools.cwd);
       conventionalChangelog.config(config);
 
+      let output = ''
+
       for await (let chunk of conventionalChangelog.writeStream()) {
         chunk = chunk.toString()
+        output += chunk
+      }
 
-        const expectedOutput = `#  (${new Date().toISOString().substring(0, 10)})
+      await expect(output).to.equal(`#  (${new Date().toISOString().substring(0, 10)})
 
 ### :rocket: Amélioration
 
-- [#123](/pull/123) remove feature info and unflag tests
+- [#123](/pull/123) remove feature info and unflag tests (PIX-1234)
 
 ### :bug: Correction
 
@@ -64,11 +63,11 @@ describe('conventional-changelog-pix', () => {
 
 ### :rewind: Retour en arrière
 
-- [#101112](/pull/101112) Revert "[TECH] Déplacer le plugin eslint 1024pix"
+- [#101112](/pull/101112) Revert "[TECH] Déplacer le plugin eslint 1024pix (PIX-999) (#2)"
 
 ### :building_construction: Tech
 
-- [#101112](/pull/101112) Ensure primitive value contexts are escaped.
+- [#101112](/pull/101112) Ensure primitive value contexts are escaped. (PIX-4567)
 
 ### :arrow_up: Montée de version
 
@@ -76,14 +75,13 @@ describe('conventional-changelog-pix', () => {
 
 ### :coffee: Autre
 
-- [#131415](/pull/131415) Make ArrayProxy public`
-        await expect(chunk).to.contain(expectedOutput)
+- [#131415](/pull/131415) Make ArrayProxy public
+`)
 
-        expect(chunk).not.toContain('CLEANUP')
-        expect(chunk).not.toContain('FEATURE')
-        expect(chunk).not.toContain('Bad')
-      }
-    })
+      expect(output).not.toContain('CLEANUP')
+      expect(output).not.toContain('FEATURE')
+      expect(output).not.toContain('Bad')
+  })
   })
 
   describe('Recommended bump', () => {
@@ -101,6 +99,8 @@ describe('conventional-changelog-pix', () => {
       { commitTitles: ['[BREAKING] remove feature info and unflag tests'], expectedReleaseType: 'major' },
       { commitTitles: ['[FEATURE] remove feature info and unflag tests'], expectedReleaseType: 'minor' },
       { commitTitles: ['[BUGFIX] remove feature info and unflag tests'], expectedReleaseType: 'patch' },
+      { commitTitles: ['[TECH] remove feature info and unflag tests'], expectedReleaseType: 'patch' },
+      { commitTitles: ['[BUMP] remove feature info and unflag tests'], expectedReleaseType: 'patch' },
     ]
 
     testCases.forEach(({ commitTitles, expectedReleaseType }) => {
@@ -118,6 +118,8 @@ describe('conventional-changelog-pix', () => {
       testTools.gitDummyCommit(['[BREAKING] remove feature info and unflag tests'])
       testTools.gitDummyCommit(['[FEATURE] remove feature info and unflag tests'])
       testTools.gitDummyCommit(['[BUGFIX] remove feature info and unflag tests'])
+      testTools.gitDummyCommit(['[TECH] remove feature info and unflag tests'])
+      testTools.gitDummyCommit(['[BUMP] remove feature info and unflag tests'])
 
       const bumper = new Bumper(testTools.cwd).config(config);
       const recommendation = await bumper.bump(config.whatBump);

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -19,67 +19,58 @@ describe('Integration', () => {
         pr: undefined,
         scope: undefined,
         tag: undefined,
-        merge: null,
         revert: null
       });
     });
 
-    test('it should return necessary fields for Pix merge commit', async () => {
-      const mergeCommit = parser.parse("[FEATURE] Second feature \n\n #12");
+    test('it should return necessary fields for Pix commit', async () => {
+      const mergeCommit = parser.parse("[FEATURE] Second feature (#12)");
 
       expect(pickNecessary(mergeCommit)).toEqual({
-        header: " #12",
-        pr: "12",
-        scope: "Second feature ",
+        header: "[FEATURE] Second feature (#12)",
         tag: "FEATURE",
-        merge: '[FEATURE] Second feature ',
+        scope: "Second feature",
+        pr: "12",
         revert: null
       });
     });
 
-    test('it should return necessary fields without pr when pr number is not in description', async () => {
-      const commitWithTagButWithoutPRNumberInDescription = parser.parse("[FEATURE] Third feature");
+    test('it should return necessary fields for Pix commit with PR in title', async () => {
+      const mergeCommit = parser.parse("[FEATURE] Second feature (PIX-1234) (#12)");
 
-      expect(pickNecessary(commitWithTagButWithoutPRNumberInDescription)).toEqual({
-        header: null,
-        merge: "[FEATURE] Third feature",
-        pr: undefined,
-        scope: "Third feature",
+      expect(pickNecessary(mergeCommit)).toEqual({
+        header: "[FEATURE] Second feature (PIX-1234) (#12)",
         tag: "FEATURE",
+        scope: "Second feature (PIX-1234)",
+        pr: "12",
+        revert: null
+      });
+    });
+
+    test('it should return necessary fields without pr number', async () => {
+      const mergeCommit = parser.parse("[FEATURE] Third feature");
+
+      expect(pickNecessary(mergeCommit)).toEqual({
+        header: "[FEATURE] Third feature",
+        tag: "FEATURE",
+        scope: "Third feature",
+        pr: null,
         revert: null
       });
     });
 
     test('revert commit should be parsed correctly', async () => {
-      const revertCommit = parser.parse("Revert \"[TECH] Déplacer le plugin eslint 1024pix\"\n\n #123");
+      const revertCommit = parser.parse("Revert \"[TECH] Déplacer le plugin eslint 1024pix (PIX-1234) (#12)\" (#24)");
 
       expect(pickNecessary(revertCommit)).toEqual({
-        header: "Revert \"[TECH] Déplacer le plugin eslint 1024pix\"",
-        scope: undefined,
+        header: "Revert \"[TECH] Déplacer le plugin eslint 1024pix (PIX-1234) (#12)\" (#24)",
         tag: undefined,
-        merge: null,
+        scope: undefined,
         pr: undefined,
         revert: {
-          pr: "123",
-          scope: "Déplacer le plugin eslint 1024pix",
           tag: "TECH",
-        }
-      });
-    });
-
-    test('revert commit should be parsed correctly with pr number in title', async () => {
-      const revertCommit = parser.parse("Revert \"[TECH] Déplacer le plugin eslint 1024pix (PIX-1234)\"\n\n #123");
-
-      expect(pickNecessary(revertCommit)).toEqual({
-        header: "Revert \"[TECH] Déplacer le plugin eslint 1024pix (PIX-1234)\"",
-        scope: undefined,
-        tag: undefined,
-        merge: null,
-        pr: undefined,
-        revert: {
-          pr: "123",
-          scope: "Déplacer le plugin eslint 1024pix (PIX-1234)",
-          tag: "TECH",
+          scope: "Déplacer le plugin eslint 1024pix (PIX-1234) (#12)",
+          pr: "24",
         }
       });
     });
@@ -92,7 +83,6 @@ const pickNecessary = (commit) => {
     header: commit.header,
     tag: commit.tag,
     scope: commit.scope,
-    merge: commit.merge,
     revert: commit.revert
   }
 }


### PR DESCRIPTION
## 🪧 Problème

On est passé des merge commits aux squash commits avec la merge queue.

## 🌈 Proposition

Modifier la génération du changelog pour gérer les squash commits.

## ✊ Remarques

N/A

## 🎉 Pour tester

Tests de la CI
